### PR TITLE
Sort list of wavelength changepoints

### DIFF
--- a/src/fairmat_readers_transmission/perkin_elmers_asc.py
+++ b/src/fairmat_readers_transmission/perkin_elmers_asc.py
@@ -227,7 +227,7 @@ def read_monochromator_slit_width(metadata: list, logger: 'BoundLogger') -> list
     for i, el in enumerate(output_list):
         if isinstance(el['value'], float):
             output_list[i]['value'] *= ureg.nanometer
-    return output_list
+    return sorted(output_list, key=lambda x: x['wavelength'])
 
 
 def read_detector_integration_time(metadata: list, logger: 'BoundLogger') -> list:
@@ -247,7 +247,7 @@ def read_detector_integration_time(metadata: list, logger: 'BoundLogger') -> lis
     for i, el in enumerate(output_list):
         if isinstance(el['value'], float):
             output_list[i]['value'] *= ureg.s
-    return output_list
+    return sorted(output_list, key=lambda x: x['wavelength'])
 
 
 def read_detector_nir_gain(metadata: list, logger: 'BoundLogger') -> list:
@@ -267,7 +267,7 @@ def read_detector_nir_gain(metadata: list, logger: 'BoundLogger') -> list:
     for i, el in enumerate(output_list):
         if isinstance(el['value'], float):
             output_list[i]['value'] *= ureg.dimensionless
-    return output_list
+    return sorted(output_list, key=lambda x: x['wavelength'])
 
 
 def read_detector_change_wavelength(metadata: list, logger: 'BoundLogger') -> list:
@@ -284,7 +284,9 @@ def read_detector_change_wavelength(metadata: list, logger: 'BoundLogger') -> li
     if not metadata[43]:
         return None
     try:
-        return np.array([float(x) for x in metadata[43].split()]) * ureg.nanometer
+        return (
+            np.array(sorted([float(x) for x in metadata[43].split()])) * ureg.nanometer
+        )
     except ValueError as e:
         if logger is not None:
             logger.warning(f'Error in reading the detector change wavelength.\n{e}')
@@ -326,7 +328,9 @@ def read_monochromator_change_wavelength(metadata: list, logger: 'BoundLogger') 
     if not metadata[41]:
         return None
     try:
-        return np.array([float(x) for x in metadata[41].split()]) * ureg.nanometer
+        return (
+            np.array(sorted([float(x) for x in metadata[41].split()])) * ureg.nanometer
+        )
     except ValueError as e:
         if logger is not None:
             logger.warning(
@@ -349,7 +353,9 @@ def read_lamp_change_wavelength(metadata: list, logger: 'BoundLogger') -> list:
     if not metadata[42]:
         return None
     try:
-        return np.array([float(x) for x in metadata[42].split()]) * ureg.nanometer
+        return (
+            np.array(sorted([float(x) for x in metadata[42].split()])) * ureg.nanometer
+        )
     except ValueError as e:
         if logger is not None:
             logger.warning(f'Error in reading the lamp change wavelength.\n{e}')

--- a/src/fairmat_readers_transmission/perkin_elmers_asc.py
+++ b/src/fairmat_readers_transmission/perkin_elmers_asc.py
@@ -128,9 +128,9 @@ def read_attenuation_percentage(metadata: list, logger) -> Dict[str, int]:
             if val == '':
                 continue
             if 'S' in key:
-                output_dict['sample'] = int(val) * ureg.dimensionless
+                output_dict['sample'] = float(val) * ureg.dimensionless
             elif 'R' in key:
-                output_dict['reference'] = int(val) * ureg.dimensionless
+                output_dict['reference'] = float(val) * ureg.dimensionless
     except ValueError as e:
         if logger is not None:
             logger.warning(f'Error in reading the attenuation data.\n{e}')

--- a/tests/data/3DM_test01.Probe.Raw.json
+++ b/tests/data/3DM_test01.Probe.Raw.json
@@ -11,30 +11,30 @@
   "common_beam_mask_percentage": "100.0",
   "is_common_beam_depolarizer_on": true,
   "attenuation_percentage": {
-    "sample": "100",
-    "reference": "100"
+    "sample": "100.0",
+    "reference": "100.0"
   },
   "detector_integration_time": [
     {
-      "wavelength": "3350.0",
-      "value": "0.18"
+      "wavelength": "860.8",
+      "value": "0.16"
     },
     {
       "wavelength": "1800.8",
       "value": "0.17"
     },
     {
-      "wavelength": "860.8",
-      "value": "0.16"
+      "wavelength": "3350.0",
+      "value": "0.18"
     }
   ],
   "detector_NIR_gain": [
     {
-      "wavelength": "3350.0",
+      "wavelength": "1800.8",
       "value": "1.0"
     },
     {
-      "wavelength": "1800.8",
+      "wavelength": "3350.0",
       "value": "1.0"
     }
   ],
@@ -45,20 +45,20 @@
   "wavelength_units": "nm",
   "monochromator_slit_width": [
     {
-      "wavelength": "3350.0",
-      "value": "8.0"
-    },
-    {
-      "wavelength": "1800.8",
-      "value": "2.1"
+      "wavelength": "750.0",
+      "value": "1.75"
     },
     {
       "wavelength": "860.8",
       "value": "1.95"
     },
     {
-      "wavelength": "750.0",
-      "value": "1.75"
+      "wavelength": "1800.8",
+      "value": "2.1"
+    },
+    {
+      "wavelength": "3350.0",
+      "value": "8.0"
     }
   ],
   "monochromator_change_wavelength": "(1,)",

--- a/tests/data/F4-P3HT 1-10 0,5 mgml.Probe.Raw.json
+++ b/tests/data/F4-P3HT 1-10 0,5 mgml.Probe.Raw.json
@@ -11,16 +11,16 @@
   "common_beam_mask_percentage": "100.0",
   "is_common_beam_depolarizer_on": null,
   "attenuation_percentage": {
-    "sample": "100",
-    "reference": "100"
+    "sample": "100.0",
+    "reference": "100.0"
   },
   "detector_integration_time": [
     {
-      "wavelength": "3350.0",
+      "wavelength": "860.8",
       "value": "0.2"
     },
     {
-      "wavelength": "860.8",
+      "wavelength": "3350.0",
       "value": "0.2"
     }
   ],
@@ -37,12 +37,12 @@
   "wavelength_units": "nm",
   "monochromator_slit_width": [
     {
-      "wavelength": "3350.0",
-      "value": "servo"
-    },
-    {
       "wavelength": "860.8",
       "value": "2.0"
+    },
+    {
+      "wavelength": "3350.0",
+      "value": "servo"
     }
   ],
   "monochromator_change_wavelength": "(1,)",

--- a/tests/data/KTF-D.Probe.Raw.json
+++ b/tests/data/KTF-D.Probe.Raw.json
@@ -11,12 +11,12 @@
   "common_beam_mask_percentage": "100.0",
   "is_common_beam_depolarizer_on": true,
   "attenuation_percentage": {
-    "sample": "100",
-    "reference": "100"
+    "sample": "100.0",
+    "reference": "100.0"
   },
   "detector_integration_time": [
     {
-      "wavelength": "3350.0",
+      "wavelength": "860.8",
       "value": "0.2"
     },
     {
@@ -24,17 +24,17 @@
       "value": "0.2"
     },
     {
-      "wavelength": "860.8",
+      "wavelength": "3350.0",
       "value": "0.2"
     }
   ],
   "detector_NIR_gain": [
     {
-      "wavelength": "3350.0",
+      "wavelength": "1800.8",
       "value": "1.0"
     },
     {
-      "wavelength": "1800.8",
+      "wavelength": "3350.0",
       "value": "1.0"
     }
   ],
@@ -45,16 +45,16 @@
   "wavelength_units": "nm",
   "monochromator_slit_width": [
     {
-      "wavelength": "3350.0",
-      "value": "servo"
+      "wavelength": "860.8",
+      "value": "2.0"
     },
     {
       "wavelength": "1800.8",
       "value": "servo"
     },
     {
-      "wavelength": "860.8",
-      "value": "2.0"
+      "wavelength": "3350.0",
+      "value": "servo"
     }
   ],
   "monochromator_change_wavelength": "(1,)",

--- a/tests/data/Sample5926.Probe.Raw.json
+++ b/tests/data/Sample5926.Probe.Raw.json
@@ -11,17 +11,17 @@
   "common_beam_mask_percentage": "90.0",
   "is_common_beam_depolarizer_on": true,
   "attenuation_percentage": {
-    "sample": "1",
-    "reference": "1"
+    "sample": "1.0",
+    "reference": "1.0"
   },
   "detector_integration_time": [
     {
-      "wavelength": "3350.0",
-      "value": "0.28"
-    },
-    {
       "wavelength": "860.9",
       "value": "0.24"
+    },
+    {
+      "wavelength": "3350.0",
+      "value": "0.28"
     }
   ],
   "detector_NIR_gain": [
@@ -37,12 +37,12 @@
   "wavelength_units": "nm",
   "monochromator_slit_width": [
     {
-      "wavelength": "3350.0",
-      "value": "2.4"
-    },
-    {
       "wavelength": "860.8",
       "value": "2.05"
+    },
+    {
+      "wavelength": "3350.0",
+      "value": "2.4"
     }
   ],
   "monochromator_change_wavelength": "(1,)",

--- a/tests/data/sphere_test01.Probe.Raw.json
+++ b/tests/data/sphere_test01.Probe.Raw.json
@@ -11,12 +11,12 @@
   "common_beam_mask_percentage": "90.0",
   "is_common_beam_depolarizer_on": true,
   "attenuation_percentage": {
-    "sample": "100",
-    "reference": "100"
+    "sample": "100.0",
+    "reference": "100.0"
   },
   "detector_integration_time": [
     {
-      "wavelength": "3350.0",
+      "wavelength": "860.8",
       "value": "0.2"
     },
     {
@@ -24,17 +24,17 @@
       "value": "0.2"
     },
     {
-      "wavelength": "860.8",
+      "wavelength": "3350.0",
       "value": "0.2"
     }
   ],
   "detector_NIR_gain": [
     {
-      "wavelength": "3350.0",
+      "wavelength": "1800.8",
       "value": "7.0"
     },
     {
-      "wavelength": "1800.8",
+      "wavelength": "3350.0",
       "value": "7.0"
     }
   ],
@@ -45,7 +45,7 @@
   "wavelength_units": "nm",
   "monochromator_slit_width": [
     {
-      "wavelength": "3350.0",
+      "wavelength": "860.8",
       "value": "2.0"
     },
     {
@@ -53,7 +53,7 @@
       "value": "2.0"
     },
     {
-      "wavelength": "860.8",
+      "wavelength": "3350.0",
       "value": "2.0"
     }
   ],


### PR DESCRIPTION
- The list of wavelength change points and settings for wavelength range are sorted ascendingly. Lower wavelength ranges are present at lower indices of the list.
- Convert attenuation percentages into `float`, not `int`.