### PR TITLE
Do not assign units in-place

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,19 +56,7 @@ select = [
     "PL", # pylint
 ]
 ignore = [
-    "E501", # Line too long ({width} > {limit} characters)
-    "E701", # Multiple statements on one line (colon)
-    "E731", # Do not assign a lambda expression, use a def
-    "E402",  # Module level import not at top of file
-    "PLR0911", # Too many return statements
-    "PLR0912", # Too many branches
-    "PLR0913", # Too many arguments in function definition
-    "PLR0915", # Too many statements
-    "PLR2004", # Magic value used instead of constant
-    "PLW0603", # Using the global statement
-    "PLW2901", # redefined-loop-name
-    "PLR1714", # consider-using-in
-    "PLR5501", # else-if-used
+    "PLC0415",  # `import` should be at the top-level of a file
 ]
 fixable = ["ALL"]
 

--- a/src/fairmat_readers_transmission/perkin_elmers_asc.py
+++ b/src/fairmat_readers_transmission/perkin_elmers_asc.py
@@ -198,11 +198,8 @@ def read_long_line(line: str, logger: 'BoundLogger') -> list:
                         'value': try_float(key_value_pair_list[1]),
                     }
                 )
-            else:
-                if logger is not None:
-                    logger.warning(
-                        f'Unexpected value while reading the long line: {line}'
-                    )
+            elif logger is not None:
+                logger.warning(f'Unexpected value while reading the long line: {line}')
         except ValueError as e:
             if logger is not None:
                 logger.warning(f'Error in reading the long line.\n{e}')

--- a/src/fairmat_readers_transmission/readers.py
+++ b/src/fairmat_readers_transmission/readers.py
@@ -148,6 +148,8 @@ def read_perkin_elmer_asc(
             )
 
     output.update(restructure_measured_data(data))
-    output['measured_wavelength'] *= ureg(output['wavelength_units'])
+    output['measured_wavelength'] = output['measured_wavelength'] * ureg(
+        output['wavelength_units']
+    )
 
     return output

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -58,6 +58,6 @@ asc_test_files = glob.glob(os.path.join(os.path.dirname(__file__), 'data', '*.as
 def test_read_perkin_elmer_asc(asc_file):
     output = read_perkin_elmer_asc(asc_file)
     convert_quantity_to_string(output)
-    with open(f'{asc_file.replace(".asc",".json")}', 'r', encoding='utf-8') as f:
+    with open(f'{asc_file.replace(".asc", ".json")}', 'r', encoding='utf-8') as f:
         reference = json.load(f)
     assert output == reference


### PR DESCRIPTION
`readers.py` builds `measured_wavelength` from `data.index.values`. With newer NumPy/Pandas versions, that array can be returned as read-only, and the subsequent Pint unit conversion hits an in-place path that raises `ValueError: output array is read-only`. This change ensures the wavelength data is writable before attaching units.